### PR TITLE
fix: mobile nav scrollable with social icons pinned at bottom

### DIFF
--- a/components/AajaMenu.vue
+++ b/components/AajaMenu.vue
@@ -203,13 +203,14 @@ nav {
   right: 0;
   top: 0;
   background: var(--primary);
-  padding: 50px;
+  padding: 80px 50px 40px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
+  overflow: hidden;
 
   @include breakpoint(mobile) {
-    padding-left: 20px;
+    padding: 70px 20px 30px;
   }
 }
 
@@ -220,10 +221,18 @@ ul {
 }
 
 #navMenu {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
   li {
     width: 100%;
     overflow: hidden;
     border-bottom: 1px solid var(--white);
+    flex-shrink: 0;
   }
 
   a {
@@ -255,11 +264,13 @@ ul {
 }
 
 #navSocials {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 20px;
   flex-gap: 20px;
-  margin-top: 40px;
+  margin-top: 20px;
+  padding-top: 10px;
 
   li {
     width: 30px;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,6 +20,7 @@ export default {
   head: {
     title: 'Aaja Music',
     meta: [
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       // hid is used as unique identifier. Do not use `vmid` for it as it will not work
       {
         hid: 'description',


### PR DESCRIPTION
## Summary

- **AajaMenu**: `#navMenu` is now `flex: 1 / overflow-y: auto` so nav items scroll when they exceed the viewport height on mobile; `#navSocials` has `flex-shrink: 0` and sits outside the scrollable container, always visible at the bottom
- **nuxt.config**: adds explicit `width=device-width, initial-scale=1` viewport meta tag so mobile browsers render at device width (was previously relying on `@nuxtjs/pwa` to inject it)

## Test plan

- [ ] Open menu on mobile — items should be centered when they fit, scrollable when they don't
- [ ] Social icons always visible at the bottom of the nav panel regardless of scroll position
- [ ] Desktop nav unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)